### PR TITLE
adding special <data type=""> node handling

### DIFF
--- a/jquery.taconite.js
+++ b/jquery.taconite.js
@@ -26,9 +26,9 @@ $.taconite.defaults = {
 
 // add 'replace' and 'replaceContent' plugins (conditionally)
 if (typeof $.fn.replace == 'undefined')
-    $.fn.replace = function(a) { 
-		this.after(a);
-		this.remove(); 
+    $.fn.replace = function(a) {
+        this.after(a);
+        this.remove();
 };
 if (typeof $.fn.replaceContent == 'undefined')
     $.fn.replaceContent = function(a) { return this.empty().append(a); };
@@ -38,8 +38,8 @@ $.expr[':'].taconiteTag = function(a) { return a.taconiteTag === 1; };
 // allow auto-detection to be enabled/disabled on-demand
 $.taconite.enableAutoDetection = function(b) {
     $.taconite.autodetect = b;
-	if (oldHttpData)
-		$.httpData = b ? oldHttpData : detect;
+    if (oldHttpData)
+        $.httpData = b ? oldHttpData : detect;
 };
 
 var logCount = 0;
@@ -50,28 +50,28 @@ function log() {
 };
 
 var parseJSON = $.parseJSON || function(s) {
-	return window['eval']('(' + s + ')');
+    return window['eval']('(' + s + ')');
 };
 
 function httpData( xhr, type, s ) { // mostly lifted from jq1.4.4
-	var ct = xhr.getResponseHeader('content-type') || '',
-		xml = type === 'xml' || !type && ct.indexOf('xml') >= 0,
-		data = xml ? xhr.responseXML : xhr.responseText;
+    var ct = xhr.getResponseHeader('content-type') || '',
+        xml = type === 'xml' || !type && ct.indexOf('xml') >= 0,
+        data = xml ? xhr.responseXML : xhr.responseText;
 
-	if (xml && data.documentElement.nodeName === 'parsererror') {
-		$.error && $.error('parsererror');
-	}
-	if (s && s.dataFilter) {
-		data = s.dataFilter(data, type);
-	}
-	if (typeof data === 'string') {
-		if (type === 'json' || !type && ct.indexOf('json') >= 0) {
-			data = parseJSON(data);
-		} else if (type === "script" || !type && ct.indexOf("javascript") >= 0) {
-			$.globalEval(data);
-		}
-	}
-	return data;
+    if (xml && data.documentElement.nodeName === 'parsererror') {
+        $.error && $.error('parsererror');
+    }
+    if (s && s.dataFilter) {
+        data = s.dataFilter(data, type);
+    }
+    if (typeof data === 'string') {
+        if (type === 'json' || !type && ct.indexOf('json') >= 0) {
+            data = parseJSON(data);
+        } else if (type === "script" || !type && ct.indexOf("javascript") >= 0) {
+            $.globalEval(data);
+        }
+    }
+    return data;
 };
 
 function detect(xhr, type, s) {
@@ -83,9 +83,9 @@ function detect(xhr, type, s) {
     }
     var data = httpData(xhr, type, s); // call original method
     if (data && data.documentElement) {
-		$.taconite(data);
+        $.taconite(data);
     }
-    else { 
+    else {
         log('jQuery core httpData returned: ' + data);
         log('httpData: response is not XML (or not "valid" XML)');
     }
@@ -94,39 +94,39 @@ function detect(xhr, type, s) {
 
 // 1.5+ hook
 $.ajaxPrefilter && $.ajaxPrefilter(function( options, originalOptions, jqXHR ) {
-	jqXHR.success(function( data, status, jqXHR ) {
-		if ($.taconite.autodetect)
-			detect(jqXHR, options.dataType, options);
-	});
+    jqXHR.success(function( data, status, jqXHR ) {
+        if ($.taconite.autodetect)
+            detect(jqXHR, options.dataType, options);
+    });
 });
 
 // < 1.5 hook
 var oldHttpData = $.httpData;
 if ($.httpData)
- 	$.httpData = detect;  // replace jQuery's httpData method
+     $.httpData = detect;  // replace jQuery's httpData method
 
-function processDoc(xml) { 
+function processDoc(xml) {
     var status = true, ex;
     try {
-		if (typeof xml == 'string')
-			xml = convert(xml);
-		if (!xml) {
-			log('$.taconite invoked without valid document; nothing to process');
-			return false;
-		}
-		
-		var root = xml.documentElement.tagName;
-		log('XML document root: ', root);
-		
-		var taconiteDoc = $('taconite', xml)[0];
-			
-		if (!taconiteDoc) {
-			log('document does not contain <taconite> element; nothing to process');
-			return false;
-		}
-		
-		$.event.trigger('taconite-begin-notify', [taconiteDoc]);
-        status = go(taconiteDoc); 
+        if (typeof xml == 'string')
+            xml = convert(xml);
+        if (!xml) {
+            log('$.taconite invoked without valid document; nothing to process');
+            return false;
+        }
+
+        var root = xml.documentElement.tagName;
+        log('XML document root: ', root);
+
+        var taconiteDoc = $('taconite', xml)[0];
+
+        if (!taconiteDoc) {
+            log('document does not contain <taconite> element; nothing to process');
+            return false;
+        }
+
+        $.event.trigger('taconite-begin-notify', [taconiteDoc]);
+        status = go(taconiteDoc);
     } catch(e) {
         status = ex = e;
     }
@@ -136,27 +136,27 @@ function processDoc(xml) {
 
 // convert string to xml document
 function convert(s) {
-	var doc;
-	log('attempting string to document conversion');
-	try {
-		if (window.DOMParser) {
-			var parser = new DOMParser();
-			doc = parser.parseFromString(s, 'text/xml');
-		}
-		else {
-			doc = $("<xml>")[0];
-			doc.async = 'false';
-			doc.loadXML(s);
-		}
-	}
-	catch(e) {
-		if (window.console && window.console.error)
-			window.console.error('[taconite] ERROR parsing XML string for conversion: ' + e);
-		throw e;
-	}
-	var ok = doc && doc.documentElement && doc.documentElement.tagName != 'parsererror';
-	log('conversion ', ok ? 'successful!' : 'FAILED');
-	return doc;
+    var doc;
+    log('attempting string to document conversion');
+    try {
+        if (window.DOMParser) {
+            var parser = new DOMParser();
+            doc = parser.parseFromString(s, 'text/xml');
+        }
+        else {
+            doc = $("<xml>")[0];
+            doc.async = 'false';
+            doc.loadXML(s);
+        }
+    }
+    catch(e) {
+        if (window.console && window.console.error)
+            window.console.error('[taconite] ERROR parsing XML string for conversion: ' + e);
+        throw e;
+    }
+    var ok = doc && doc.documentElement && doc.documentElement.tagName != 'parsererror';
+    log('conversion ', ok ? 'successful!' : 'FAILED');
+    return doc;
 };
 
 
@@ -175,8 +175,8 @@ function go(xml) {
         throw e;
     }
     return true;
-    
-// process the taconite commands    
+
+// process the taconite commands
     function process(commands) {
         var doPostProcess = 0;
         for(var i=0; i < commands.length; i++) {
@@ -218,38 +218,38 @@ function go(xml) {
                     break;
                 // support numeric primitives
                 var n = Number(v);
-				if (v == n)
-					v = n;
+                if (v == n)
+                    v = n;
                 a.push(v);
             }
 
             if ($.taconite.debug) {
-				var args = '';
-				if (els)
-					args = '...';
-				else {
-					for (var k=0; k < a.length; k++) {
-						if (k > 0)
-							args += ',';
-						var val = a[k];
-						var isString = typeof val == 'string';
-						if (isString)
-							args += '\'';
-						args += val;							
-						if (isString)
-							args += '\'';
-					}
-				}
+                var args = '';
+                if (els)
+                    args = '...';
+                else {
+                    for (var k=0; k < a.length; k++) {
+                        if (k > 0)
+                            args += ',';
+                        var val = a[k];
+                        var isString = typeof val == 'string';
+                        if (isString)
+                            args += '\'';
+                        args += val;
+                        if (isString)
+                            args += '\'';
+                    }
+                }
                 log("invoking command: $('", q, "').", cmd, '('+ args +')');
             }
             jq[cmd].apply(jq,a);
         }
         // apply dynamic fixes
-        if (doPostProcess) 
+        if (doPostProcess)
             postProcess();
-    
+
         function postProcess() {
-            if ($.browser.mozilla) return; 
+            if ($.browser.mozilla) return;
             // post processing fixes go here; currently there is only one:
             // fix1: opera, IE6, Safari/Win don't maintain selected options in all cases (thanks to Karel Fučík for this!)
             $('select:taconiteTag').each(function() {
@@ -265,13 +265,13 @@ function go(xml) {
                 this.taconiteTag = null;
             });
         };
-        
+
         function cleanse(els) {
             for (var i=0, a=[]; i < els.length; i++)
                 if (els[i].nodeType == 1) a.push(els[i]);
             return a;
         };
-        
+
         function createNode(node) {
             var type = node.nodeType;
             if (type == 1) return createElement(node);
@@ -279,29 +279,29 @@ function go(xml) {
             if (type == 4) return handleCDATA(node.nodeValue);
             return null;
         };
-        
+
         function handleCDATA(s) {
             var el = document.createElement(cdataWrap);
             el.innerHTML = s;
-            
+
             // remove wrapper node if possible
             var $el = $(el), $ch = $el.children();
             if ($ch.size() == 1)
                 return $ch[0];
             return el;
         };
-        
+
         function fixTextNode(s) {
             if ($.browser.msie) s = s.replace(/\n/g, '\r').replace(/\s+/g, ' ');
             return document.createTextNode(s);
         };
-        
+
         function createElement(node) {
             var e, tag = node.tagName.toLowerCase();
             // some elements in IE need to be created with attrs inline
             if ($.browser.msie) {
                 var type = node.getAttribute('type');
-                if (tag == 'table' || type == 'radio' || type == 'checkbox' || tag == 'button' || 
+                if (tag == 'table' || type == 'radio' || type == 'checkbox' || tag == 'button' ||
                     (tag == 'select' && node.getAttribute('multiple'))) {
                     e = document.createElement('<' + tag + ' ' + copyAttrs(null, node, true) + '>');
                 }
@@ -311,7 +311,7 @@ function go(xml) {
                 // copyAttrs(e, node, tag == 'option' && $.browser.safari);
                 copyAttrs(e, node);
             }
-            
+
             // IE fix; colspan must be explicitly set
             if ($.browser.msie && tag == 'td') {
                 var colspan = node.getAttribute('colspan');
@@ -335,7 +335,7 @@ function go(xml) {
             }
             return e;
         };
-        
+
         function copyAttrs(dest, src, inline) {
             for (var i=0, attr=''; i < src.attributes.length; i++) {
                 var a = src.attributes[i], n = $.trim(a.name), v = $.trim(a.value);


### PR DESCRIPTION
useful TODO still is to pass the data back to the original request's callbacks so that 'taconite-complete-notify' binding is not required. i'm thinking of piggybacking on jqXHR but unsure. if you merge this, prolly bump the version #, too.

thanks,
Leon
